### PR TITLE
Fix policy for CloudWatch Alarms

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
       variable = "AWS:SourceOwner"
 
       values = [
-        "arn:aws:iam::${data.aws_caller_identity.default.account_id}:root",
+        "${data.aws_caller_identity.default.account_id}",
       ]
     }
   }


### PR DESCRIPTION
## what
* Use aws account id rather than arn

## why
*  was not receiving any alarms via SNS until this change was made.