### PR TITLE
Upgrade to be terraform .12 compatible & other changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 build-harness
 .build-harness
+
+# vscode files
+*.code-workspace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,4 +7,3 @@ repos:
   rev: v1.31.0
   hooks:
     - id: terraform_fmt
-    - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,4 @@ repos:
   rev: v1.31.0
   hooks:
     - id: terraform_fmt
+    - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ resource "aws_db_instance" "default" {
 
 module "rds_alarms" {
   source         = "git::https://github.com/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms.git?ref=tags/0.1.5"
-  db_instance_id = "${aws_db_instance.default.id}"
+  db_instance_ids = "${[aws_db_instance.default.id]}"
   aws_sns_topic_arn = "${aws_sns_topic.default.arn}"
 }
 ```
@@ -83,7 +83,7 @@ module "rds_alarms" {
 | burst_balance_threshold | The minimum percent of General Purpose SSD (gp2) burst-bucket I/O credits available. | string | `20` | no |
 | cpu_credit_balance_threshold | The minimum number of CPU credits (t2 instances only) available. | string | `20` | no |
 | cpu_utilization_threshold | The maximum percentage of CPU utilization. | string | `80` | no |
-| db_instance_id | The instance ID of the RDS database instance that you want to monitor. | string | - | yes |
+| db_instance_ids | The instance IDs of the RDS database instance that you want to monitor. | string | - | yes |
 | disk_queue_depth_threshold | The maximum number of outstanding IOs (read/write requests) waiting to access the disk. | string | `64` | no |
 | free_storage_space_threshold | The minimum amount of available storage space in Byte. | string | `2000000000` | no |
 | freeable_memory_threshold | The minimum amount of available random access memory in Byte. | string | `64000000` | no |

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ resource "aws_db_instance" "default" {
 
 module "rds_alarms" {
   source         = "git::https://github.com/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms.git?ref=tags/0.1.5"
-  db_instance_ids = ["${aws_db_instance.default.id}"]
-  aws_sns_topic_arn = "${aws_sns_topic.default.arn}"
+  db_instance_ids = [aws_db_instance.default.id]
+  aws_sns_topic_arn = aws_sns_topic.default.arn
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 | Memory  | FreeableMemory   | `<`                  | 64 MB     | This number is calculated from our experience with RDS workloads.                                                                                                                                      |
 | Memory  | SwapUsage        | `>`                  | 256 MB    | Sometimes you can not entirely avoid swapping. But once the database accesses paged memory, it will slow down.                                                                                         |
 
+The module will also alert on `failure` type events. See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html for a list of events.
 
 
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ module "rds_alarms" {
 | cpu_utilization_threshold | The maximum percentage of CPU utilization. | string | `80` | no |
 | db_instance_ids | The instance IDs of the RDS database instance that you want to monitor. | string | - | yes |
 | aws_sns_topic_arn | ARN of SNS topic to use. | string | - | yes |
-| alarm_name_prefix | Alarm name prefix for each alarm. | string | - | no |
+| alarm_name_prefix | Alarm name prefix for each alarm. | string | `` | no |
 | disk_queue_depth_threshold | The maximum number of outstanding IOs (read/write requests) waiting to access the disk. | string | `64` | no |
 | free_storage_space_threshold | The minimum amount of available storage space in Byte. | string | `2000000000` | no |
 | freeable_memory_threshold | The minimum amount of available random access memory in Byte. | string | `64000000` | no |

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ module "rds_alarms" {
 | cpu_credit_balance_threshold | The minimum number of CPU credits (t2 instances only) available. | string | `20` | no |
 | cpu_utilization_threshold | The maximum percentage of CPU utilization. | string | `80` | no |
 | db_instance_ids | The instance IDs of the RDS database instance that you want to monitor. | string | - | yes |
+| aws_sns_topic_arn | ARN of SNS topic to use. | string | - | yes |
 | alarm_name_prefix | Alarm name prefix for each alarm. | string | - | no |
 | disk_queue_depth_threshold | The maximum number of outstanding IOs (read/write requests) waiting to access the disk. | string | `64` | no |
 | free_storage_space_threshold | The minimum amount of available storage space in Byte. | string | `2000000000` | no |

--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ module "rds_alarms" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| burst_balance_threshold | The minimum percent of General Purpose SSD (gp2) burst-bucket I/O credits available. | string | `20` | no |
-| cpu_credit_balance_threshold | The minimum number of CPU credits (t2 instances only) available. | string | `20` | no |
-| cpu_utilization_threshold | The maximum percentage of CPU utilization. | string | `80` | no |
 | db_instance_ids | The instance IDs of the RDS database instance that you want to monitor. | list | - | yes |
 | aws_sns_topic_arn | ARN of SNS topic to use. | string | - | yes |
 | alarm_name_prefix | Alarm name prefix for each alarm. | string | `` | no |
+| burst_balance_threshold | The minimum percent of General Purpose SSD (gp2) burst-bucket I/O credits available. | string | `20` | no |
+| cpu_credit_balance_threshold | The minimum number of CPU credits (t2 instances only) available. | string | `20` | no |
+| cpu_utilization_threshold | The maximum percentage of CPU utilization. | string | `80` | no |
 | disk_queue_depth_threshold | The maximum number of outstanding IOs (read/write requests) waiting to access the disk. | string | `64` | no |
 | free_storage_space_threshold | The minimum amount of available storage space in Byte. | string | `2000000000` | no |
 | freeable_memory_threshold | The minimum amount of available random access memory in Byte. | string | `64000000` | no |

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ module "rds_alarms" {
 | cpu_credit_balance_threshold | The minimum number of CPU credits (t2 instances only) available. | string | `20` | no |
 | cpu_utilization_threshold | The maximum percentage of CPU utilization. | string | `80` | no |
 | db_instance_ids | The instance IDs of the RDS database instance that you want to monitor. | string | - | yes |
+| alarm_name_prefix | Alarm name prefix for each alarm. | string | - | no |
 | disk_queue_depth_threshold | The maximum number of outstanding IOs (read/write requests) waiting to access the disk. | string | `64` | no |
 | free_storage_space_threshold | The minimum amount of available storage space in Byte. | string | `2000000000` | no |
 | freeable_memory_threshold | The minimum amount of available random access memory in Byte. | string | `64000000` | no |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
  [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms) [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms.svg)](https://github.com/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms/releases) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 
 
-Terraform module that configures important RDS alerts using CloudWatch and sends them to an SNS topic.
+Terraform module that configures important RDS alerts using CloudWatch and sends them to the chosen SNS topic.
 
 Create a set of sane RDS CloudWatch alerts for monitoring the health of an RDS instance.
 
@@ -68,6 +68,7 @@ resource "aws_db_instance" "default" {
 module "rds_alarms" {
   source         = "git::https://github.com/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms.git?ref=tags/0.1.5"
   db_instance_id = "${aws_db_instance.default.id}"
+  aws_sns_topic_arn = "${aws_sns_topic.default.arn}"
 }
 ```
 
@@ -86,12 +87,6 @@ module "rds_alarms" {
 | free_storage_space_threshold | The minimum amount of available storage space in Byte. | string | `2000000000` | no |
 | freeable_memory_threshold | The minimum amount of available random access memory in Byte. | string | `64000000` | no |
 | swap_usage_threshold | The maximum amount of swap space used on the DB instance in Byte. | string | `256000000` | no |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| sns_topic_arn | The ARN of the SNS topic |
 
 ## Makefile Targets
 ```

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ module "rds_alarms" {
 | db_instance_ids | The instance IDs of the RDS database instance that you want to monitor. | list | - | yes |
 | aws_sns_topic_arn | ARN of SNS topic to use. | string | - | yes |
 | alarm_name_prefix | Alarm name prefix for each alarm. | string | `` | no |
+| alarm_period | The threshold is analyzed over the last X seconds, where X is alarm_period | string | `600` | no |
+| alarm_evaluation_periods | The number of periods over which data is compared to the specified threshold. | string | `1` | no |
 | burst_balance_threshold | The minimum percent of General Purpose SSD (gp2) burst-bucket I/O credits available. | string | `20` | no |
 | cpu_credit_balance_threshold | The minimum number of CPU credits (t2 instances only) available. | string | `20` | no |
 | cpu_utilization_threshold | The maximum percentage of CPU utilization. | string | `80` | no |

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ module "rds_alarms" {
 |------|-------------|:----:|:-----:|:-----:|
 | db_instance_ids | The instance IDs of the RDS database instance that you want to monitor. | list | - | yes |
 | aws_sns_topic_arn | ARN of SNS topic to use. | string | - | yes |
-| alarm_name_prefix | Alarm name prefix for each alarm. | string | `` | no |
-| alarm_period | The threshold is analyzed over the last X seconds, where X is alarm_period | string | `600` | no |
-| alarm_evaluation_periods | The number of periods over which data is compared to the specified threshold. | string | `1` | no |
+| name_prefix | Alarm name prefix for each alarm. | string | `` | no |
+| period | The threshold is analyzed over the last X seconds, where X is alarm_period | string | `600` | no |
+| evaluation_periods | The number of periods over which data is compared to the specified threshold. | string | `1` | no |
 | burst_balance_threshold | The minimum percent of General Purpose SSD (gp2) burst-bucket I/O credits available. | string | `20` | no |
 | cpu_credit_balance_threshold | The minimum number of CPU credits (t2 instances only) available. | string | `20` | no |
 | cpu_utilization_threshold | The maximum percentage of CPU utilization. | string | `80` | no |

--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ Check out [our other projects][github], [apply for a job][jobs], or [hire us][hi
 
 ### Contributors
 
-|  [![Jamie Nelson][Jamie-BitFlight_avatar]][Jamie-BitFlight_homepage]<br/>[Jamie Nelson][Jamie-BitFlight_homepage] | [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Daniel Patriche][rebelthor_avatar]][rebelthor_homepage]<br/>[Daniel Patriche][rebelthor_homepage] |
-|---|---|---|
+|  [![Jamie Nelson][Jamie-BitFlight_avatar]][Jamie-BitFlight_homepage]<br/>[Jamie Nelson][Jamie-BitFlight_homepage] | [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Daniel Patriche][rebelthor_avatar]][rebelthor_homepage]<br/>[Daniel Patriche][rebelthor_homepage] | [![Caleb15][caleb15_avatar]][caleb15_homepage]<br/>[Caleb15][caleb15_homepage] | 
+|---|---|---|---|
 
   [Jamie-BitFlight_homepage]: https://github.com/Jamie-BitFlight
   [Jamie-BitFlight_avatar]: https://github.com/Jamie-BitFlight.png?size=150
@@ -240,6 +240,5 @@ Check out [our other projects][github], [apply for a job][jobs], or [hire us][hi
   [osterman_avatar]: https://github.com/osterman.png?size=150
   [rebelthor_homepage]: https://github.com/rebelthor
   [rebelthor_avatar]: https://github.com/rebelthor.png?size=150
-
-
-
+  [caleb15_homepage]: https://github.com/caleb15
+  [caleb15_avatar]: https://github.com/caleb15.png?size=150

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ resource "aws_db_instance" "default" {
 
 module "rds_alarms" {
   source         = "git::https://github.com/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms.git?ref=tags/0.1.5"
-  db_instance_ids = "${[aws_db_instance.default.id]}"
+  db_instance_ids = ["${aws_db_instance.default.id}"]
   aws_sns_topic_arn = "${aws_sns_topic.default.arn}"
 }
 ```
@@ -83,7 +83,7 @@ module "rds_alarms" {
 | burst_balance_threshold | The minimum percent of General Purpose SSD (gp2) burst-bucket I/O credits available. | string | `20` | no |
 | cpu_credit_balance_threshold | The minimum number of CPU credits (t2 instances only) available. | string | `20` | no |
 | cpu_utilization_threshold | The maximum percentage of CPU utilization. | string | `80` | no |
-| db_instance_ids | The instance IDs of the RDS database instance that you want to monitor. | string | - | yes |
+| db_instance_ids | The instance IDs of the RDS database instance that you want to monitor. | list | - | yes |
 | aws_sns_topic_arn | ARN of SNS topic to use. | string | - | yes |
 | alarm_name_prefix | Alarm name prefix for each alarm. | string | `` | no |
 | disk_queue_depth_threshold | The maximum number of outstanding IOs (read/write requests) waiting to access the disk. | string | `64` | no |

--- a/README.md
+++ b/README.md
@@ -233,12 +233,15 @@ Check out [our other projects][github], [apply for a job][jobs], or [hire us][hi
 
 ### Contributors
 
-|  [![Jamie Nelson][Jamie-BitFlight_avatar]][Jamie-BitFlight_homepage]<br/>[Jamie Nelson][Jamie-BitFlight_homepage] | [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] |
-|---|---|
+|  [![Jamie Nelson][Jamie-BitFlight_avatar]][Jamie-BitFlight_homepage]<br/>[Jamie Nelson][Jamie-BitFlight_homepage] | [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Daniel Patriche][rebelthor_avatar]][rebelthor_homepage]<br/>[Daniel Patriche][rebelthor_homepage] |
+|---|---|---|
 
   [Jamie-BitFlight_homepage]: https://github.com/Jamie-BitFlight
   [Jamie-BitFlight_avatar]: https://github.com/Jamie-BitFlight.png?size=150
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://github.com/osterman.png?size=150
+  [rebelthor_homepage]: https://github.com/rebelthor
+  [rebelthor_avatar]: https://github.com/rebelthor.png?size=150
+
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -69,8 +69,8 @@ examples: |-
 
   module "rds_alarms" {
     source         = "git::https://github.com/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms.git?ref=tags/0.1.5"
-    db_instance_ids = ["${aws_db_instance.default.id}"]
-    aws_sns_topic_arn = "${aws_sns_topic.default.arn}"
+    db_instance_ids = [aws_db_instance.default.id]
+    aws_sns_topic_arn = aws_sns_topic.default.arn
   }
   ```
 

--- a/README.yaml
+++ b/README.yaml
@@ -107,3 +107,5 @@ contributors:
     github: "osterman"
   - name: "Daniel Patriche"
     github: "rebelthor"
+  - name: "Caleb Sparks"
+    github: "caleb15"

--- a/README.yaml
+++ b/README.yaml
@@ -65,7 +65,7 @@ examples: |-
 
   module "rds_alarms" {
     source         = "git::https://github.com/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms.git?ref=tags/0.1.5"
-    db_instance_id = "${aws_db_instance.default.id}"
+    db_instance_ids = "${aws_db_instance.default.id}"
   }
   ```
 

--- a/README.yaml
+++ b/README.yaml
@@ -63,9 +63,14 @@ examples: |-
     skip_final_snapshot  = "true"
   }
 
+  resource "aws_sns_topic" "default" {
+    name_prefix = "rds-threshold-alerts"
+  }
+
   module "rds_alarms" {
     source         = "git::https://github.com/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms.git?ref=tags/0.1.5"
-    db_instance_ids = "${aws_db_instance.default.id}"
+    db_instance_ids = ["${aws_db_instance.default.id}"]
+    aws_sns_topic_arn = "${aws_sns_topic.default.arn}"
   }
   ```
 

--- a/README.yaml
+++ b/README.yaml
@@ -105,3 +105,5 @@ contributors:
     github: "Jamie-BitFlight"
   - name: "Erik Osterman"
     github: "osterman"
+  - name: "Daniel Patriche"
+    github: "rebelthor"

--- a/alarms.tf
+++ b/alarms.tf
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = "${var.db_instance_ids}"
+    DBInstanceIdentifier = var.db_instance_ids[count.index]
   }
 }
 
@@ -44,7 +44,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = "${var.db_instance_ids}"
+    DBInstanceIdentifier = var.db_instance_ids[count.index]
   }
 }
 
@@ -63,7 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = "${var.db_instance_ids}"
+    DBInstanceIdentifier = var.db_instance_ids[count.index]
   }
 }
 
@@ -82,7 +82,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = "${var.db_instance_ids}"
+    DBInstanceIdentifier = var.db_instance_ids[count.index]
   }
 }
 
@@ -101,7 +101,7 @@ resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = "${var.db_instance_ids}"
+    DBInstanceIdentifier = var.db_instance_ids[count.index]
   }
 }
 
@@ -120,7 +120,7 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = "${var.db_instance_ids}"
+    DBInstanceIdentifier = var.db_instance_ids[count.index]
   }
 }
 
@@ -139,6 +139,6 @@ resource "aws_cloudwatch_metric_alarm" "swap_usage_too_high" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = "${var.db_instance_ids}"
+    DBInstanceIdentifier = var.db_instance_ids[count.index]
   }
 }

--- a/alarms.tf
+++ b/alarms.tf
@@ -1,17 +1,17 @@
 locals {
   thresholds = {
-    BurstBalanceThreshold     = "${min(max(var.burst_balance_threshold, 0), 100)}"
-    CPUUtilizationThreshold   = "${min(max(var.cpu_utilization_threshold, 0), 100)}"
-    CPUCreditBalanceThreshold = "${max(var.cpu_credit_balance_threshold, 0)}"
-    DiskQueueDepthThreshold   = "${max(var.disk_queue_depth_threshold, 0)}"
-    FreeableMemoryThreshold   = "${max(var.freeable_memory_threshold, 0)}"
-    FreeStorageSpaceThreshold = "${max(var.free_storage_space_threshold, 0)}"
-    SwapUsageThreshold        = "${max(var.swap_usage_threshold, 0)}"
+    BurstBalanceThreshold     = min(max(var.burst_balance_threshold, 0), 100)
+    CPUUtilizationThreshold   = min(max(var.cpu_utilization_threshold, 0), 100)
+    CPUCreditBalanceThreshold = max(var.cpu_credit_balance_threshold, 0)
+    DiskQueueDepthThreshold   = max(var.disk_queue_depth_threshold, 0)
+    FreeableMemoryThreshold   = max(var.freeable_memory_threshold, 0)
+    FreeStorageSpaceThreshold = max(var.free_storage_space_threshold, 0)
+    SwapUsageThreshold        = max(var.swap_usage_threshold, 0)
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
-  count               = "${length(var.db_instance_ids)}"
+  count               = length(var.db_instance_ids)
   alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-burst_balance_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
@@ -19,18 +19,18 @@ resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
   namespace           = "AWS/RDS"
   period              = "600"
   statistic           = "Average"
-  threshold           = "${local.thresholds["BurstBalanceThreshold"]}"
+  threshold           = local.thresholds["BurstBalanceThreshold"]
   alarm_description   = "Average database storage burst balance over last 10 minutes too low, expect a significant performance drop soon"
-  alarm_actions       = ["${var.aws_sns_topic_arn}"]
-  ok_actions          = ["${var.aws_sns_topic_arn}"]
+  alarm_actions       = [var.aws_sns_topic_arn]
+  ok_actions          = [var.aws_sns_topic_arn]
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${var.db_instance_ids}"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
-  count               = "${length(var.db_instance_ids)}"
+  count               = length(var.db_instance_ids)
   alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-cpu_utilization_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
@@ -38,18 +38,18 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   namespace           = "AWS/RDS"
   period              = "600"
   statistic           = "Average"
-  threshold           = "${local.thresholds["CPUUtilizationThreshold"]}"
+  threshold           = local.thresholds["CPUUtilizationThreshold"]
   alarm_description   = "Average database CPU utilization over last 10 minutes too high"
-  alarm_actions       = ["${var.aws_sns_topic_arn}"]
-  ok_actions          = ["${var.aws_sns_topic_arn}"]
+  alarm_actions       = [var.aws_sns_topic_arn]
+  ok_actions          = [var.aws_sns_topic_arn]
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${var.db_instance_ids}"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
-  count               = "${length(var.db_instance_ids)}"
+  count               = length(var.db_instance_ids)
   alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-cpu_credit_balance_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
@@ -57,18 +57,18 @@ resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
   namespace           = "AWS/RDS"
   period              = "600"
   statistic           = "Average"
-  threshold           = "${local.thresholds["CPUCreditBalanceThreshold"]}"
+  threshold           = local.thresholds["CPUCreditBalanceThreshold"]
   alarm_description   = "Average database CPU credit balance over last 10 minutes too low, expect a significant performance drop soon"
-  alarm_actions       = ["${var.aws_sns_topic_arn}"]
-  ok_actions          = ["${var.aws_sns_topic_arn}"]
+  alarm_actions       = [var.aws_sns_topic_arn]
+  ok_actions          = [var.aws_sns_topic_arn]
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${var.db_instance_ids}"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
-  count               = "${length(var.db_instance_ids)}"
+  count               = length(var.db_instance_ids)
   alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-disk_queue_depth_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
@@ -76,18 +76,18 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
   namespace           = "AWS/RDS"
   period              = "600"
   statistic           = "Average"
-  threshold           = "${local.thresholds["DiskQueueDepthThreshold"]}"
+  threshold           = local.thresholds["DiskQueueDepthThreshold"]
   alarm_description   = "Average database disk queue depth over last 10 minutes too high, performance may suffer"
-  alarm_actions       = ["${var.aws_sns_topic_arn}"]
-  ok_actions          = ["${var.aws_sns_topic_arn}"]
+  alarm_actions       = [var.aws_sns_topic_arn]
+  ok_actions          = [var.aws_sns_topic_arn]
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${var.db_instance_ids}"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
-  count               = "${length(var.db_instance_ids)}"
+  count               = length(var.db_instance_ids)
   alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-freeable_memory_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
@@ -95,18 +95,18 @@ resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
   namespace           = "AWS/RDS"
   period              = "600"
   statistic           = "Average"
-  threshold           = "${local.thresholds["FreeableMemoryThreshold"]}"
+  threshold           = local.thresholds["FreeableMemoryThreshold"]
   alarm_description   = "Average database freeable memory over last 10 minutes too low, performance may suffer"
-  alarm_actions       = ["${var.aws_sns_topic_arn}"]
-  ok_actions          = ["${var.aws_sns_topic_arn}"]
+  alarm_actions       = [var.aws_sns_topic_arn]
+  ok_actions          = [var.aws_sns_topic_arn]
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${var.db_instance_ids}"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
-  count               = "${length(var.db_instance_ids)}"
+  count               = length(var.db_instance_ids)
   alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-free_storage_space_threshold"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
@@ -114,18 +114,18 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
   namespace           = "AWS/RDS"
   period              = "600"
   statistic           = "Average"
-  threshold           = "${local.thresholds["FreeStorageSpaceThreshold"]}"
+  threshold           = local.thresholds["FreeStorageSpaceThreshold"]
   alarm_description   = "Average database free storage space over last 10 minutes too low"
-  alarm_actions       = ["${var.aws_sns_topic_arn}"]
-  ok_actions          = ["${var.aws_sns_topic_arn}"]
+  alarm_actions       = [var.aws_sns_topic_arn]
+  ok_actions          = [var.aws_sns_topic_arn]
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${var.db_instance_ids}"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "swap_usage_too_high" {
-  count               = "${length(var.db_instance_ids)}"
+  count               = length(var.db_instance_ids)
   alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-swap_usage_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
@@ -133,12 +133,12 @@ resource "aws_cloudwatch_metric_alarm" "swap_usage_too_high" {
   namespace           = "AWS/RDS"
   period              = "600"
   statistic           = "Average"
-  threshold           = "${local.thresholds["SwapUsageThreshold"]}"
+  threshold           = local.thresholds["SwapUsageThreshold"]
   alarm_description   = "Average database swap usage over last 10 minutes too high, performance may suffer"
-  alarm_actions       = ["${var.aws_sns_topic_arn}"]
-  ok_actions          = ["${var.aws_sns_topic_arn}"]
+  alarm_actions       = [var.aws_sns_topic_arn]
+  ok_actions          = [var.aws_sns_topic_arn]
 
-  dimensions {
+  dimensions = {
     DBInstanceIdentifier = "${var.db_instance_ids}"
   }
 }

--- a/alarms.tf
+++ b/alarms.tf
@@ -12,15 +12,15 @@ locals {
 
 resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
   count               = length(var.db_instance_ids)
-  alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-burst_balance_too_low"
+  alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-burst_balance_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_periods
   metric_name         = "BurstBalance"
   namespace           = "AWS/RDS"
-  period              = var.alarm_period
+  period              = var.period
   statistic           = "Average"
   threshold           = local.thresholds["BurstBalanceThreshold"]
-  alarm_description   = "Average database storage burst balance over last ${var.alarm_period/60} minutes too low, expect a significant performance drop soon"
+  alarm_description   = "Average database storage burst balance over last ${var.period/60} minutes too low, expect a significant performance drop soon"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -31,15 +31,15 @@ resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
 
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   count               = length(var.db_instance_ids)
-  alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-cpu_utilization_too_high"
+  alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-cpu_utilization_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_periods
   metric_name         = "CPUUtilization"
   namespace           = "AWS/RDS"
-  period              = var.alarm_period
+  period              = var.period
   statistic           = "Average"
   threshold           = local.thresholds["CPUUtilizationThreshold"]
-  alarm_description   = "Average database CPU utilization over last ${var.alarm_period/60} minutes too high"
+  alarm_description   = "Average database CPU utilization over last ${var.period/60} minutes too high"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -50,15 +50,15 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
 
 resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
   count               = length(var.db_instance_ids)
-  alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-cpu_credit_balance_too_low"
+  alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-cpu_credit_balance_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_periods
   metric_name         = "CPUCreditBalance"
   namespace           = "AWS/RDS"
-  period              = var.alarm_period
+  period              = var.period
   statistic           = "Average"
   threshold           = local.thresholds["CPUCreditBalanceThreshold"]
-  alarm_description   = "Average database CPU credit balance over last ${var.alarm_period/60} minutes too low, expect a significant performance drop soon"
+  alarm_description   = "Average database CPU credit balance over last ${var.period/60} minutes too low, expect a significant performance drop soon"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -69,15 +69,15 @@ resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
 
 resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
   count               = length(var.db_instance_ids)
-  alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-disk_queue_depth_too_high"
+  alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-disk_queue_depth_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_periods
   metric_name         = "DiskQueueDepth"
   namespace           = "AWS/RDS"
-  period              = var.alarm_period
+  period              = var.period
   statistic           = "Average"
   threshold           = local.thresholds["DiskQueueDepthThreshold"]
-  alarm_description   = "Average database disk queue depth over last ${var.alarm_period/60} minutes too high, performance may suffer"
+  alarm_description   = "Average database disk queue depth over last ${var.period/60} minutes too high, performance may suffer"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -88,15 +88,15 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
 
 resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
   count               = length(var.db_instance_ids)
-  alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-freeable_memory_too_low"
+  alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-freeable_memory_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_periods
   metric_name         = "FreeableMemory"
   namespace           = "AWS/RDS"
-  period              = var.alarm_period
+  period              = var.period
   statistic           = "Average"
   threshold           = local.thresholds["FreeableMemoryThreshold"]
-  alarm_description   = "Average database freeable memory over last ${var.alarm_period/60} minutes too low, performance may suffer"
+  alarm_description   = "Average database freeable memory over last ${var.period/60} minutes too low, performance may suffer"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -107,15 +107,15 @@ resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
 
 resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
   count               = length(var.db_instance_ids)
-  alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-free_storage_space_threshold"
+  alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-free_storage_space_threshold"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_periods
   metric_name         = "FreeStorageSpace"
   namespace           = "AWS/RDS"
-  period              = var.alarm_period
+  period              = var.period
   statistic           = "Average"
   threshold           = local.thresholds["FreeStorageSpaceThreshold"]
-  alarm_description   = "Average database free storage space over last ${var.alarm_period/60} minutes too low"
+  alarm_description   = "Average database free storage space over last ${var.period/60} minutes too low"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -126,15 +126,15 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
 
 resource "aws_cloudwatch_metric_alarm" "swap_usage_too_high" {
   count               = length(var.db_instance_ids)
-  alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-swap_usage_too_high"
+  alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-swap_usage_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_periods
   metric_name         = "SwapUsage"
   namespace           = "AWS/RDS"
-  period              = var.alarm_period
+  period              = var.period
   statistic           = "Average"
   threshold           = local.thresholds["SwapUsageThreshold"]
-  alarm_description   = "Average database swap usage over last ${var.alarm_period/60} minutes too high, performance may suffer"
+  alarm_description   = "Average database swap usage over last ${var.period/60} minutes too high, performance may suffer"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 

--- a/alarms.tf
+++ b/alarms.tf
@@ -14,13 +14,13 @@ resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
   count               = length(var.db_instance_ids)
   alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-burst_balance_too_low"
   comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.evaluation_periods
   metric_name         = "BurstBalance"
   namespace           = "AWS/RDS"
-  period              = "600"
+  period              = var.alarm_period
   statistic           = "Average"
   threshold           = local.thresholds["BurstBalanceThreshold"]
-  alarm_description   = "Average database storage burst balance over last 10 minutes too low, expect a significant performance drop soon"
+  alarm_description   = "Average database storage burst balance over last ${var.alarm_period/60} minutes too low, expect a significant performance drop soon"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -33,13 +33,13 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   count               = length(var.db_instance_ids)
   alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-cpu_utilization_too_high"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.evaluation_periods
   metric_name         = "CPUUtilization"
   namespace           = "AWS/RDS"
-  period              = "600"
+  period              = var.alarm_period
   statistic           = "Average"
   threshold           = local.thresholds["CPUUtilizationThreshold"]
-  alarm_description   = "Average database CPU utilization over last 10 minutes too high"
+  alarm_description   = "Average database CPU utilization over last ${var.alarm_period/60} minutes too high"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -52,13 +52,13 @@ resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
   count               = length(var.db_instance_ids)
   alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-cpu_credit_balance_too_low"
   comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.evaluation_periods
   metric_name         = "CPUCreditBalance"
   namespace           = "AWS/RDS"
-  period              = "600"
+  period              = var.alarm_period
   statistic           = "Average"
   threshold           = local.thresholds["CPUCreditBalanceThreshold"]
-  alarm_description   = "Average database CPU credit balance over last 10 minutes too low, expect a significant performance drop soon"
+  alarm_description   = "Average database CPU credit balance over last ${var.alarm_period/60} minutes too low, expect a significant performance drop soon"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -71,13 +71,13 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
   count               = length(var.db_instance_ids)
   alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-disk_queue_depth_too_high"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.evaluation_periods
   metric_name         = "DiskQueueDepth"
   namespace           = "AWS/RDS"
-  period              = "600"
+  period              = var.alarm_period
   statistic           = "Average"
   threshold           = local.thresholds["DiskQueueDepthThreshold"]
-  alarm_description   = "Average database disk queue depth over last 10 minutes too high, performance may suffer"
+  alarm_description   = "Average database disk queue depth over last ${var.alarm_period/60} minutes too high, performance may suffer"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -90,13 +90,13 @@ resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
   count               = length(var.db_instance_ids)
   alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-freeable_memory_too_low"
   comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.evaluation_periods
   metric_name         = "FreeableMemory"
   namespace           = "AWS/RDS"
-  period              = "600"
+  period              = var.alarm_period
   statistic           = "Average"
   threshold           = local.thresholds["FreeableMemoryThreshold"]
-  alarm_description   = "Average database freeable memory over last 10 minutes too low, performance may suffer"
+  alarm_description   = "Average database freeable memory over last ${var.alarm_period/60} minutes too low, performance may suffer"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -109,13 +109,13 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
   count               = length(var.db_instance_ids)
   alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-free_storage_space_threshold"
   comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.evaluation_periods
   metric_name         = "FreeStorageSpace"
   namespace           = "AWS/RDS"
-  period              = "600"
+  period              = var.alarm_period
   statistic           = "Average"
   threshold           = local.thresholds["FreeStorageSpaceThreshold"]
-  alarm_description   = "Average database free storage space over last 10 minutes too low"
+  alarm_description   = "Average database free storage space over last ${var.alarm_period/60} minutes too low"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -128,13 +128,13 @@ resource "aws_cloudwatch_metric_alarm" "swap_usage_too_high" {
   count               = length(var.db_instance_ids)
   alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-swap_usage_too_high"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.evaluation_periods
   metric_name         = "SwapUsage"
   namespace           = "AWS/RDS"
-  period              = "600"
+  period              = var.alarm_period
   statistic           = "Average"
   threshold           = local.thresholds["SwapUsageThreshold"]
-  alarm_description   = "Average database swap usage over last 10 minutes too high, performance may suffer"
+  alarm_description   = "Average database swap usage over last ${var.alarm_period/60} minutes too high, performance may suffer"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 

--- a/alarms.tf
+++ b/alarms.tf
@@ -12,7 +12,7 @@ locals {
 
 resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
   count               = "${length(var.db_instance_ids)}"
-  alarm_name          = "${var.db_instance_ids[count.index]}-burst_balance_too_low"
+  alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-burst_balance_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "BurstBalance"
@@ -31,7 +31,7 @@ resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
 
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   count               = "${length(var.db_instance_ids)}"
-  alarm_name          = "${var.db_instance_ids[count.index]}-cpu_utilization_too_high"
+  alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-cpu_utilization_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "CPUUtilization"
@@ -50,7 +50,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
 
 resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
   count               = "${length(var.db_instance_ids)}"
-  alarm_name          = "${var.db_instance_ids[count.index]}-cpu_credit_balance_too_low"
+  alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-cpu_credit_balance_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "CPUCreditBalance"
@@ -69,7 +69,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
 
 resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
   count               = "${length(var.db_instance_ids)}"
-  alarm_name          = "${var.db_instance_ids[count.index]}-disk_queue_depth_too_high"
+  alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-disk_queue_depth_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "DiskQueueDepth"
@@ -88,7 +88,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
 
 resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
   count               = "${length(var.db_instance_ids)}"
-  alarm_name          = "${var.db_instance_ids[count.index]}-freeable_memory_too_low"
+  alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-freeable_memory_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "FreeableMemory"
@@ -107,7 +107,7 @@ resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
 
 resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
   count               = "${length(var.db_instance_ids)}"
-  alarm_name          = "${var.db_instance_ids[count.index]}-free_storage_space_threshold"
+  alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-free_storage_space_threshold"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "FreeStorageSpace"
@@ -126,7 +126,7 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
 
 resource "aws_cloudwatch_metric_alarm" "swap_usage_too_high" {
   count               = "${length(var.db_instance_ids)}"
-  alarm_name          = "${var.db_instance_ids[count.index]}-swap_usage_too_high"
+  alarm_name          = "${var.alarm_name_prefix}${var.db_instance_ids[count.index]}-swap_usage_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "SwapUsage"

--- a/alarms.tf
+++ b/alarms.tf
@@ -1,5 +1,4 @@
 locals {
-  db_instance_ids = length(var.db_instance_ids)
   thresholds = {
     BurstBalanceThreshold     = min(max(var.burst_balance_threshold, 0), 100)
     CPUUtilizationThreshold   = min(max(var.cpu_utilization_threshold, 0), 100)
@@ -12,8 +11,8 @@ locals {
 }
 
 resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
-  count               = local.db_instance_ids
-  alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-burst_balance_too_low"
+  for_each            = var.db_instance_ids
+  alarm_name          = "${var.name_prefix}${each.value}-burst_balance_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_periods
   metric_name         = "BurstBalance"
@@ -26,13 +25,13 @@ resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = var.db_instance_ids[count.index]
+    DBInstanceIdentifier = each.name
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
-  count               = local.db_instance_ids
-  alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-cpu_utilization_too_high"
+  for_each            = var.db_instance_ids
+  alarm_name          = "${var.name_prefix}${each.value}-cpu_utilization_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_periods
   metric_name         = "CPUUtilization"
@@ -45,13 +44,13 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = var.db_instance_ids[count.index]
+    DBInstanceIdentifier = veach.value
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
-  count               = local.db_instance_ids
-  alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-cpu_credit_balance_too_low"
+  for_each            = var.db_instance_ids
+  alarm_name          = "${var.name_prefix}${each.value}-cpu_credit_balance_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_periods
   metric_name         = "CPUCreditBalance"
@@ -64,13 +63,13 @@ resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = var.db_instance_ids[count.index]
+    DBInstanceIdentifier = veach.value
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
-  count               = local.db_instance_ids
-  alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-disk_queue_depth_too_high"
+  for_each            = var.db_instance_ids
+  alarm_name          = "${var.name_prefix}${each.value}-disk_queue_depth_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_periods
   metric_name         = "DiskQueueDepth"
@@ -83,13 +82,13 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = var.db_instance_ids[count.index]
+    DBInstanceIdentifier = veach.value
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
-  count               = local.db_instance_ids
-  alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-freeable_memory_too_low"
+  for_each            = var.db_instance_ids
+  alarm_name          = "${var.name_prefix}${each.value}-freeable_memory_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_periods
   metric_name         = "FreeableMemory"
@@ -102,13 +101,13 @@ resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = var.db_instance_ids[count.index]
+    DBInstanceIdentifier = veach.value
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
-  count               = local.db_instance_ids
-  alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-free_storage_space_threshold"
+  for_each            = var.db_instance_ids
+  alarm_name          = "${var.name_prefix}${each.value}-free_storage_space_threshold"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_periods
   datapoints_to_alarm = var.datapoints_to_alarm
@@ -122,13 +121,13 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = var.db_instance_ids[count.index]
+    DBInstanceIdentifier = veach.value
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "swap_usage_too_high" {
-  count               = local.db_instance_ids
-  alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-swap_usage_too_high"
+  for_each            = var.db_instance_ids
+  alarm_name          = "${var.name_prefix}${each.value}-swap_usage_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_periods
   metric_name         = "SwapUsage"
@@ -141,12 +140,12 @@ resource "aws_cloudwatch_metric_alarm" "swap_usage_too_high" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = var.db_instance_ids[count.index]
+    DBInstanceIdentifier = veach.value
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "rapid-free-space-decrease" {
-  count                     = length(var.db_master_ids)
+  for_each                  = var.db_instance_ids
   alarm_name                = "${var.name_prefix}${var.db_master_ids[count.index]}-rapid-free-space-decrease"
   comparison_operator       = "LessThanLowerThreshold"
   evaluation_periods        = "2"

--- a/alarms.tf
+++ b/alarms.tf
@@ -11,7 +11,7 @@ locals {
 }
 
 resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
-  alarm_name          = "burst_balance_too_low"
+  alarm_name          = "${var.db_instance_id}-burst_balance_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "BurstBalance"
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
-  alarm_name          = "cpu_utilization_too_high"
+  alarm_name          = "${var.db_instance_id}-cpu_utilization_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "CPUUtilization"
@@ -47,7 +47,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
-  alarm_name          = "cpu_credit_balance_too_low"
+  alarm_name          = "${var.db_instance_id}-cpu_credit_balance_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "CPUCreditBalance"
@@ -65,7 +65,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
-  alarm_name          = "disk_queue_depth_too_high"
+  alarm_name          = "${var.db_instance_id}-disk_queue_depth_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "DiskQueueDepth"
@@ -83,7 +83,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
-  alarm_name          = "freeable_memory_too_low"
+  alarm_name          = "${var.db_instance_id}-freeable_memory_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "FreeableMemory"
@@ -101,7 +101,7 @@ resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
-  alarm_name          = "free_storage_space_threshold"
+  alarm_name          = "${var.db_instance_id}-free_storage_space_threshold"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "FreeStorageSpace"
@@ -119,7 +119,7 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "swap_usage_too_high" {
-  alarm_name          = "swap_usage_too_high"
+  alarm_name          = "${var.db_instance_id}-swap_usage_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "SwapUsage"

--- a/alarms.tf
+++ b/alarms.tf
@@ -1,4 +1,5 @@
 locals {
+  db_instance_ids = length(var.db_instance_ids)
   thresholds = {
     BurstBalanceThreshold     = min(max(var.burst_balance_threshold, 0), 100)
     CPUUtilizationThreshold   = min(max(var.cpu_utilization_threshold, 0), 100)
@@ -11,7 +12,7 @@ locals {
 }
 
 resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
-  count               = length(var.db_instance_ids)
+  count               = local.db_instance_ids
   alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-burst_balance_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_periods
@@ -30,7 +31,7 @@ resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
-  count               = length(var.db_instance_ids)
+  count               = local.db_instance_ids
   alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-cpu_utilization_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_periods
@@ -49,7 +50,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
-  count               = length(var.db_instance_ids)
+  count               = local.db_instance_ids
   alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-cpu_credit_balance_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_periods
@@ -68,7 +69,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
-  count               = length(var.db_instance_ids)
+  count               = local.db_instance_ids
   alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-disk_queue_depth_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_periods
@@ -87,7 +88,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
-  count               = length(var.db_instance_ids)
+  count               = local.db_instance_ids
   alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-freeable_memory_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_periods
@@ -106,7 +107,7 @@ resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
-  count               = length(var.db_instance_ids)
+  count               = local.db_instance_ids
   alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-free_storage_space_threshold"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_periods
@@ -126,7 +127,7 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "swap_usage_too_high" {
-  count               = length(var.db_instance_ids)
+  count               = local.db_instance_ids
   alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-swap_usage_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_periods

--- a/alarms.tf
+++ b/alarms.tf
@@ -20,7 +20,7 @@ resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
   period              = var.period
   statistic           = "Average"
   threshold           = local.thresholds["BurstBalanceThreshold"]
-  alarm_description   = "Average database storage burst balance over last ${var.period/60} minutes too low, expect a significant performance drop soon"
+  alarm_description   = "Average database storage burst balance over last ${var.period / 60} minutes too low, expect a significant performance drop soon"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -39,7 +39,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   period              = var.period
   statistic           = "Average"
   threshold           = local.thresholds["CPUUtilizationThreshold"]
-  alarm_description   = "Average database CPU utilization over last ${var.period/60} minutes too high"
+  alarm_description   = "Average database CPU utilization over last ${var.period / 60} minutes too high"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -58,7 +58,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
   period              = var.period
   statistic           = "Average"
   threshold           = local.thresholds["CPUCreditBalanceThreshold"]
-  alarm_description   = "Average database CPU credit balance over last ${var.period/60} minutes too low, expect a significant performance drop soon"
+  alarm_description   = "Average database CPU credit balance over last ${var.period / 60} minutes too low, expect a significant performance drop soon"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -77,7 +77,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
   period              = var.period
   statistic           = "Average"
   threshold           = local.thresholds["DiskQueueDepthThreshold"]
-  alarm_description   = "Average database disk queue depth over last ${var.period/60} minutes too high, performance may suffer"
+  alarm_description   = "Average database disk queue depth over last ${var.period / 60} minutes too high, performance may suffer"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -96,7 +96,7 @@ resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
   period              = var.period
   statistic           = "Average"
   threshold           = local.thresholds["FreeableMemoryThreshold"]
-  alarm_description   = "Average database freeable memory over last ${var.period/60} minutes too low, performance may suffer"
+  alarm_description   = "Average database freeable memory over last ${var.period / 60} minutes too low, performance may suffer"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -115,7 +115,7 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
   period              = var.period
   statistic           = "Average"
   threshold           = local.thresholds["FreeStorageSpaceThreshold"]
-  alarm_description   = "Average database free storage space over last ${var.period/60} minutes too low"
+  alarm_description   = "Average database free storage space over last ${var.period / 60} minutes too low"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
@@ -134,11 +134,46 @@ resource "aws_cloudwatch_metric_alarm" "swap_usage_too_high" {
   period              = var.period
   statistic           = "Average"
   threshold           = local.thresholds["SwapUsageThreshold"]
-  alarm_description   = "Average database swap usage over last ${var.period/60} minutes too high, performance may suffer"
+  alarm_description   = "Average database swap usage over last ${var.period / 60} minutes too high, performance may suffer"
   alarm_actions       = [var.aws_sns_topic_arn]
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
     DBInstanceIdentifier = var.db_instance_ids[count.index]
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rapid-free-space-decrease" {
+  count                     = length(var.db_master_ids)
+  alarm_name                = "${var.name_prefix}${var.db_master_ids[count.index]}-rapid-free-space-decrease"
+  comparison_operator       = "LessThanLowerThreshold"
+  evaluation_periods        = "2"
+  threshold_metric_id       = "e1"
+  alarm_description         = "RDS Free storage space"
+  insufficient_data_actions = [var.aws_sns_topic_arn]
+  ok_actions                = [var.aws_sns_topic_arn]
+  alarm_actions             = [var.aws_sns_topic_arn]
+
+  metric_query {
+    id          = "e1"
+    expression  = "ANOMALY_DETECTION_BAND(m1)"
+    label       = "FreeStorageSpace (Expected)"
+    return_data = "true"
+  }
+
+  metric_query {
+    id = "m1"
+    return_data = "true"
+
+    metric {
+      metric_name = "FreeStorageSpace"
+      namespace   = "AWS/RDS"
+      period      = "300"
+      stat        = "Average"
+
+      dimensions = {
+        DBInstanceIdentifier = var.db_master_ids[count.index]
+      }
+    }
   }
 }

--- a/alarms.tf
+++ b/alarms.tf
@@ -44,7 +44,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = veach.value
+    DBInstanceIdentifier = each.value
   }
 }
 
@@ -63,7 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = veach.value
+    DBInstanceIdentifier = each.value
   }
 }
 
@@ -82,7 +82,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = veach.value
+    DBInstanceIdentifier = each.value
   }
 }
 
@@ -101,7 +101,7 @@ resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = veach.value
+    DBInstanceIdentifier = each.value
   }
 }
 
@@ -121,7 +121,7 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = veach.value
+    DBInstanceIdentifier = each.value
   }
 }
 
@@ -140,13 +140,13 @@ resource "aws_cloudwatch_metric_alarm" "swap_usage_too_high" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = veach.value
+    DBInstanceIdentifier = each.value
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "rapid-free-space-decrease" {
-  for_each                  = var.db_instance_ids
-  alarm_name                = "${var.name_prefix}${var.db_master_ids[count.index]}-rapid-free-space-decrease"
+  for_each                  = var.db_master_ids
+  alarm_name                = "${var.name_prefix}${each.value}-rapid-free-space-decrease"
   comparison_operator       = "LessThanLowerThreshold"
   evaluation_periods        = "2"
   threshold_metric_id       = "e1"
@@ -173,7 +173,7 @@ resource "aws_cloudwatch_metric_alarm" "rapid-free-space-decrease" {
       stat        = "Average"
 
       dimensions = {
-        DBInstanceIdentifier = var.db_master_ids[count.index]
+        DBInstanceIdentifier = each.value
       }
     }
   }

--- a/alarms.tf
+++ b/alarms.tf
@@ -162,7 +162,7 @@ resource "aws_cloudwatch_metric_alarm" "rapid-free-space-decrease" {
   }
 
   metric_query {
-    id = "m1"
+    id          = "m1"
     return_data = "true"
 
     metric {

--- a/alarms.tf
+++ b/alarms.tf
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
   ok_actions          = [var.aws_sns_topic_arn]
 
   dimensions = {
-    DBInstanceIdentifier = each.name
+    DBInstanceIdentifier = each.value
   }
 }
 

--- a/alarms.tf
+++ b/alarms.tf
@@ -110,6 +110,7 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
   alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-free_storage_space_threshold"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_periods
+  datapoints_to_alarm = var.datapoints_to_alarm
   metric_name         = "FreeStorageSpace"
   namespace           = "AWS/RDS"
   period              = var.period

--- a/alarms.tf
+++ b/alarms.tf
@@ -20,8 +20,8 @@ resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
   statistic           = "Average"
   threshold           = "${local.thresholds["BurstBalanceThreshold"]}"
   alarm_description   = "Average database storage burst balance over last 10 minutes too low, expect a significant performance drop soon"
-  alarm_actions       = ["${aws_sns_topic.default.arn}"]
-  ok_actions          = ["${aws_sns_topic.default.arn}"]
+  alarm_actions       = ["${var.aws_sns_topic_arn}"]
+  ok_actions          = ["${var.aws_sns_topic_arn}"]
 
   dimensions = {
     DBInstanceIdentifier = "${var.db_instance_id}"
@@ -38,8 +38,8 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   statistic           = "Average"
   threshold           = "${local.thresholds["CPUUtilizationThreshold"]}"
   alarm_description   = "Average database CPU utilization over last 10 minutes too high"
-  alarm_actions       = ["${aws_sns_topic.default.arn}"]
-  ok_actions          = ["${aws_sns_topic.default.arn}"]
+  alarm_actions       = ["${var.aws_sns_topic_arn}"]
+  ok_actions          = ["${var.aws_sns_topic_arn}"]
 
   dimensions = {
     DBInstanceIdentifier = "${var.db_instance_id}"
@@ -56,8 +56,8 @@ resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
   statistic           = "Average"
   threshold           = "${local.thresholds["CPUCreditBalanceThreshold"]}"
   alarm_description   = "Average database CPU credit balance over last 10 minutes too low, expect a significant performance drop soon"
-  alarm_actions       = ["${aws_sns_topic.default.arn}"]
-  ok_actions          = ["${aws_sns_topic.default.arn}"]
+  alarm_actions       = ["${var.aws_sns_topic_arn}"]
+  ok_actions          = ["${var.aws_sns_topic_arn}"]
 
   dimensions = {
     DBInstanceIdentifier = "${var.db_instance_id}"
@@ -74,8 +74,8 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
   statistic           = "Average"
   threshold           = "${local.thresholds["DiskQueueDepthThreshold"]}"
   alarm_description   = "Average database disk queue depth over last 10 minutes too high, performance may suffer"
-  alarm_actions       = ["${aws_sns_topic.default.arn}"]
-  ok_actions          = ["${aws_sns_topic.default.arn}"]
+  alarm_actions       = ["${var.aws_sns_topic_arn}"]
+  ok_actions          = ["${var.aws_sns_topic_arn}"]
 
   dimensions = {
     DBInstanceIdentifier = "${var.db_instance_id}"
@@ -92,8 +92,8 @@ resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
   statistic           = "Average"
   threshold           = "${local.thresholds["FreeableMemoryThreshold"]}"
   alarm_description   = "Average database freeable memory over last 10 minutes too low, performance may suffer"
-  alarm_actions       = ["${aws_sns_topic.default.arn}"]
-  ok_actions          = ["${aws_sns_topic.default.arn}"]
+  alarm_actions       = ["${var.aws_sns_topic_arn}"]
+  ok_actions          = ["${var.aws_sns_topic_arn}"]
 
   dimensions = {
     DBInstanceIdentifier = "${var.db_instance_id}"
@@ -110,8 +110,8 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
   statistic           = "Average"
   threshold           = "${local.thresholds["FreeStorageSpaceThreshold"]}"
   alarm_description   = "Average database free storage space over last 10 minutes too low"
-  alarm_actions       = ["${aws_sns_topic.default.arn}"]
-  ok_actions          = ["${aws_sns_topic.default.arn}"]
+  alarm_actions       = ["${var.aws_sns_topic_arn}"]
+  ok_actions          = ["${var.aws_sns_topic_arn}"]
 
   dimensions = {
     DBInstanceIdentifier = "${var.db_instance_id}"
@@ -128,8 +128,8 @@ resource "aws_cloudwatch_metric_alarm" "swap_usage_too_high" {
   statistic           = "Average"
   threshold           = "${local.thresholds["SwapUsageThreshold"]}"
   alarm_description   = "Average database swap usage over last 10 minutes too high, performance may suffer"
-  alarm_actions       = ["${aws_sns_topic.default.arn}"]
-  ok_actions          = ["${aws_sns_topic.default.arn}"]
+  alarm_actions       = ["${var.aws_sns_topic_arn}"]
+  ok_actions          = ["${var.aws_sns_topic_arn}"]
 
   dimensions = {
     DBInstanceIdentifier = "${var.db_instance_id}"

--- a/alarms.tf
+++ b/alarms.tf
@@ -11,7 +11,8 @@ locals {
 }
 
 resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
-  alarm_name          = "${var.db_instance_id}-burst_balance_too_low"
+  count               = "${length(var.db_instance_ids)}"
+  alarm_name          = "${var.db_instance_ids[count.index]}-burst_balance_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "BurstBalance"
@@ -23,13 +24,14 @@ resource "aws_cloudwatch_metric_alarm" "burst_balance_too_low" {
   alarm_actions       = ["${var.aws_sns_topic_arn}"]
   ok_actions          = ["${var.aws_sns_topic_arn}"]
 
-  dimensions = {
-    DBInstanceIdentifier = "${var.db_instance_id}"
+  dimensions {
+    DBInstanceIdentifier = "${var.db_instance_ids}"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
-  alarm_name          = "${var.db_instance_id}-cpu_utilization_too_high"
+  count               = "${length(var.db_instance_ids)}"
+  alarm_name          = "${var.db_instance_ids[count.index]}-cpu_utilization_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "CPUUtilization"
@@ -41,13 +43,14 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   alarm_actions       = ["${var.aws_sns_topic_arn}"]
   ok_actions          = ["${var.aws_sns_topic_arn}"]
 
-  dimensions = {
-    DBInstanceIdentifier = "${var.db_instance_id}"
+  dimensions {
+    DBInstanceIdentifier = "${var.db_instance_ids}"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
-  alarm_name          = "${var.db_instance_id}-cpu_credit_balance_too_low"
+  count               = "${length(var.db_instance_ids)}"
+  alarm_name          = "${var.db_instance_ids[count.index]}-cpu_credit_balance_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "CPUCreditBalance"
@@ -59,13 +62,14 @@ resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
   alarm_actions       = ["${var.aws_sns_topic_arn}"]
   ok_actions          = ["${var.aws_sns_topic_arn}"]
 
-  dimensions = {
-    DBInstanceIdentifier = "${var.db_instance_id}"
+  dimensions {
+    DBInstanceIdentifier = "${var.db_instance_ids}"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
-  alarm_name          = "${var.db_instance_id}-disk_queue_depth_too_high"
+  count               = "${length(var.db_instance_ids)}"
+  alarm_name          = "${var.db_instance_ids[count.index]}-disk_queue_depth_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "DiskQueueDepth"
@@ -77,13 +81,14 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
   alarm_actions       = ["${var.aws_sns_topic_arn}"]
   ok_actions          = ["${var.aws_sns_topic_arn}"]
 
-  dimensions = {
-    DBInstanceIdentifier = "${var.db_instance_id}"
+  dimensions {
+    DBInstanceIdentifier = "${var.db_instance_ids}"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
-  alarm_name          = "${var.db_instance_id}-freeable_memory_too_low"
+  count               = "${length(var.db_instance_ids)}"
+  alarm_name          = "${var.db_instance_ids[count.index]}-freeable_memory_too_low"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "FreeableMemory"
@@ -95,13 +100,14 @@ resource "aws_cloudwatch_metric_alarm" "freeable_memory_too_low" {
   alarm_actions       = ["${var.aws_sns_topic_arn}"]
   ok_actions          = ["${var.aws_sns_topic_arn}"]
 
-  dimensions = {
-    DBInstanceIdentifier = "${var.db_instance_id}"
+  dimensions {
+    DBInstanceIdentifier = "${var.db_instance_ids}"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
-  alarm_name          = "${var.db_instance_id}-free_storage_space_threshold"
+  count               = "${length(var.db_instance_ids)}"
+  alarm_name          = "${var.db_instance_ids[count.index]}-free_storage_space_threshold"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "FreeStorageSpace"
@@ -113,13 +119,14 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
   alarm_actions       = ["${var.aws_sns_topic_arn}"]
   ok_actions          = ["${var.aws_sns_topic_arn}"]
 
-  dimensions = {
-    DBInstanceIdentifier = "${var.db_instance_id}"
+  dimensions {
+    DBInstanceIdentifier = "${var.db_instance_ids}"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "swap_usage_too_high" {
-  alarm_name          = "${var.db_instance_id}-swap_usage_too_high"
+  count               = "${length(var.db_instance_ids)}"
+  alarm_name          = "${var.db_instance_ids[count.index]}-swap_usage_too_high"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "SwapUsage"
@@ -131,7 +138,7 @@ resource "aws_cloudwatch_metric_alarm" "swap_usage_too_high" {
   alarm_actions       = ["${var.aws_sns_topic_arn}"]
   ok_actions          = ["${var.aws_sns_topic_arn}"]
 
-  dimensions = {
-    DBInstanceIdentifier = "${var.db_instance_id}"
+  dimensions {
+    DBInstanceIdentifier = "${var.db_instance_ids}"
   }
 }

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,7 +6,7 @@
 | burst_balance_threshold | The minimum percent of General Purpose SSD (gp2) burst-bucket I/O credits available. | string | `20` | no |
 | cpu_credit_balance_threshold | The minimum number of CPU credits (t2 instances only) available. | string | `20` | no |
 | cpu_utilization_threshold | The maximum percentage of CPU utilization. | string | `80` | no |
-| db_instance_id | The instance ID of the RDS database instance that you want to monitor. | string | - | yes |
+| db_instance_ids | The instance ID of the RDS database instance that you want to monitor. | string | - | yes |
 | disk_queue_depth_threshold | The maximum number of outstanding IOs (read/write requests) waiting to access the disk. | string | `64` | no |
 | free_storage_space_threshold | The minimum amount of available storage space in Byte. | string | `2000000000` | no |
 | freeable_memory_threshold | The minimum amount of available random access memory in Byte. | string | `64000000` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,6 +7,7 @@
 | cpu_credit_balance_threshold | The minimum number of CPU credits (t2 instances only) available. | string | `20` | no |
 | cpu_utilization_threshold | The maximum percentage of CPU utilization. | string | `80` | no |
 | db_instance_ids | The instance ID of the RDS database instance that you want to monitor. | string | - | yes |
+| aws_sns_topic_arn | ARN of SNS topic to use. | string | - | yes |
 | alarm_name_prefix | Alarm name prefix for each alarm. | string | - | no |
 | disk_queue_depth_threshold | The maximum number of outstanding IOs (read/write requests) waiting to access the disk. | string | `64` | no |
 | free_storage_space_threshold | The minimum amount of available storage space in Byte. | string | `2000000000` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,6 +7,7 @@
 | cpu_credit_balance_threshold | The minimum number of CPU credits (t2 instances only) available. | string | `20` | no |
 | cpu_utilization_threshold | The maximum percentage of CPU utilization. | string | `80` | no |
 | db_instance_ids | The instance ID of the RDS database instance that you want to monitor. | string | - | yes |
+| alarm_name_prefix | Alarm name prefix for each alarm. | string | - | no |
 | disk_queue_depth_threshold | The maximum number of outstanding IOs (read/write requests) waiting to access the disk. | string | `64` | no |
 | free_storage_space_threshold | The minimum amount of available storage space in Byte. | string | `2000000000` | no |
 | freeable_memory_threshold | The minimum amount of available random access memory in Byte. | string | `64000000` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -8,7 +8,7 @@
 | cpu_utilization_threshold | The maximum percentage of CPU utilization. | string | `80` | no |
 | db_instance_ids | The instance ID of the RDS database instance that you want to monitor. | string | - | yes |
 | aws_sns_topic_arn | ARN of SNS topic to use. | string | - | yes |
-| alarm_name_prefix | Alarm name prefix for each alarm. | string | - | no |
+| alarm_name_prefix | Alarm name prefix for each alarm. | string | `` | no |
 | disk_queue_depth_threshold | The maximum number of outstanding IOs (read/write requests) waiting to access the disk. | string | `64` | no |
 | free_storage_space_threshold | The minimum amount of available storage space in Byte. | string | `2000000000` | no |
 | freeable_memory_threshold | The minimum amount of available random access memory in Byte. | string | `64000000` | no |

--- a/examples/marbot/main.tf
+++ b/examples/marbot/main.tf
@@ -4,7 +4,7 @@ variable "marbot_endpoint_id" {
 
 locals {
   marbot_endpoint = {
-    endpoint_id = "${var.marbot_endpoint_id}"
+    endpoint_id = var.marbot_endpoint_id
     stage       = "v1"
   }
 }
@@ -14,7 +14,7 @@ variable "region" {
 }
 
 provider "aws" {
-  region = "${var.region}"
+  region = var.region
 
   # Make it faster by skipping something
   skip_get_ec2_platforms      = true
@@ -29,8 +29,8 @@ resource "aws_sns_topic" "default" {
 }
 
 resource "aws_sns_topic_subscription" "subscribe_marbot" {
-  count     = "${var.marbot_endpoint_id != "" ? 1 : 0}"
-  topic_arn = "${aws_sns_topic.default.arn}"
+  count     = var.marbot_endpoint_id != "" ? 1 : 0
+  topic_arn = aws_sns_topic.default.arn
   protocol  = "https"
   endpoint  = "https://api.marbot.io/${local.marbot_endpoint["Stage"]}/endpoint/${local.marbot_endpoint["EndpointId"]}"
 }
@@ -52,6 +52,6 @@ resource "aws_db_instance" "default" {
 
 module "rds_alarms" {
   source         = "github::https://github.com/bitflight-public/terraform-aws-rds-alerts.git?ref=master"
-  db_instance_ids = "${[aws_db_instance.default.id]}"
+  db_instance_ids = ["${aws_db_instance.default.id}"]
   aws_sns_topic_arn = "${aws_sns_topic.default.arn}"
 }

--- a/examples/marbot/main.tf
+++ b/examples/marbot/main.tf
@@ -24,9 +24,13 @@ provider "aws" {
   skip_requesting_account_id  = true
 }
 
+resource "aws_sns_topic" "default" {
+  name_prefix = "rds-threshold-alerts"
+}
+
 resource "aws_sns_topic_subscription" "subscribe_marbot" {
   count     = "${var.marbot_endpoint_id != "" ? 1 : 0}"
-  topic_arn = "${module.rds_alarms.sns_topic_arn}"
+  topic_arn = "${aws_sns_topic.default.arn}"
   protocol  = "https"
   endpoint  = "https://api.marbot.io/${local.marbot_endpoint["Stage"]}/endpoint/${local.marbot_endpoint["EndpointId"]}"
 }
@@ -49,4 +53,5 @@ resource "aws_db_instance" "default" {
 module "rds_alarms" {
   source         = "github::https://github.com/bitflight-public/terraform-aws-rds-alerts.git?ref=master"
   db_instance_ids = "${[aws_db_instance.default.id]}"
+  aws_sns_topic_arn = "${aws_sns_topic.default.arn}"
 }

--- a/examples/marbot/main.tf
+++ b/examples/marbot/main.tf
@@ -48,5 +48,5 @@ resource "aws_db_instance" "default" {
 
 module "rds_alarms" {
   source         = "github::https://github.com/bitflight-public/terraform-aws-rds-alerts.git?ref=master"
-  db_instance_id = "${aws_db_instance.default.id}"
+  db_instance_ids = "${[aws_db_instance.default.id]}"
 }

--- a/examples/marbot/main.tf
+++ b/examples/marbot/main.tf
@@ -52,6 +52,6 @@ resource "aws_db_instance" "default" {
 
 module "rds_alarms" {
   source         = "github::https://github.com/bitflight-public/terraform-aws-rds-alerts.git?ref=master"
-  db_instance_ids = ["${aws_db_instance.default.id}"]
-  aws_sns_topic_arn = "${aws_sns_topic.default.arn}"
+  db_instance_ids = [aws_db_instance.default.id]
+  aws_sns_topic_arn = aws_sns_topic.default.arn
 }

--- a/examples/marbot/main.tf
+++ b/examples/marbot/main.tf
@@ -51,7 +51,7 @@ resource "aws_db_instance" "default" {
 }
 
 module "rds_alarms" {
-  source         = "github::https://github.com/bitflight-public/terraform-aws-rds-alerts.git?ref=master"
-  db_instance_ids = [aws_db_instance.default.id]
+  source            = "github::https://github.com/bitflight-public/terraform-aws-rds-alerts.git?ref=master"
+  db_instance_ids   = [aws_db_instance.default.id]
   aws_sns_topic_arn = aws_sns_topic.default.arn
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -35,8 +35,8 @@ resource "aws_db_instance" "default" {
 
 module "rds_alarms" {
   source         = "../../"
-  db_instance_ids = ["${aws_db_instance.default.id}"]
-  aws_sns_topic_arn = "${aws_sns_topic.default.arn}"
+  db_instance_ids = [aws_db_instance.default.id]
+  aws_sns_topic_arn = aws_sns_topic.default.arn
 }
 
 output "rds_arn" {

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -14,6 +14,10 @@ provider "aws" {
   skip_requesting_account_id  = true
 }
 
+resource "aws_sns_topic" "default" {
+  name_prefix = "rds-threshold-alerts"
+}
+
 resource "aws_db_instance" "default" {
   allocated_storage    = 10
   storage_type         = "gp2"
@@ -32,10 +36,7 @@ resource "aws_db_instance" "default" {
 module "rds_alarms" {
   source         = "../../"
   db_instance_ids = "${[aws_db_instance.default.id]}"
-}
-
-output "rds_alarms_sns_topic_arn" {
-  value = "${module.rds_alarms.sns_topic_arn}"
+  aws_sns_topic_arn = "${aws_sns_topic.default.arn}"
 }
 
 output "rds_arn" {

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -31,7 +31,7 @@ resource "aws_db_instance" "default" {
 
 module "rds_alarms" {
   source         = "../../"
-  db_instance_id = "${aws_db_instance.default.id}"
+  db_instance_ids = "${[aws_db_instance.default.id]}"
 }
 
 output "rds_alarms_sns_topic_arn" {

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -4,7 +4,7 @@ variable "region" {
 }
 
 provider "aws" {
-  region = "${var.region}"
+  region = var.region
 
   # Make it faster by skipping something
   skip_get_ec2_platforms      = true
@@ -35,10 +35,10 @@ resource "aws_db_instance" "default" {
 
 module "rds_alarms" {
   source         = "../../"
-  db_instance_ids = "${[aws_db_instance.default.id]}"
+  db_instance_ids = ["${aws_db_instance.default.id}"]
   aws_sns_topic_arn = "${aws_sns_topic.default.arn}"
 }
 
 output "rds_arn" {
-  value = "${aws_db_instance.default.id}"
+  value = aws_db_instance.default.id
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -34,8 +34,8 @@ resource "aws_db_instance" "default" {
 }
 
 module "rds_alarms" {
-  source         = "../../"
-  db_instance_ids = [aws_db_instance.default.id]
+  source            = "../../"
+  db_instance_ids   = [aws_db_instance.default.id]
   aws_sns_topic_arn = aws_sns_topic.default.arn
 }
 

--- a/main.tf
+++ b/main.tf
@@ -8,12 +8,11 @@
 data "aws_caller_identity" "default" {}
 
 resource "aws_db_event_subscription" "default" {
-  count       = length(var.db_instance_ids)
   name_prefix = "rds-event-sub"
   sns_topic   = var.aws_sns_topic_arn
 
   source_type = "db-instance"
-  source_ids  = [var.db_instance_ids[count.index]]
+  source_ids  = var.db_instance_ids
 
   event_categories = [
     "failure",

--- a/main.tf
+++ b/main.tf
@@ -15,12 +15,7 @@ resource "aws_db_event_subscription" "default" {
   source_ids  = ["${var.db_instance_id}"]
 
   event_categories = [
-    "failover",
     "failure",
-    "low storage",
-    "maintenance",
-    "notification",
-    "recovery",
   ]
 
   depends_on = ["aws_sns_topic_policy.default"]

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,3 @@
-# resource "aws_cloudwatch_event_target" "sns" {
-#   rule       = "${aws_cloudwatch_event_rule.default.name}"
-#   target_id  = "SendToSNS"
-#   arn        = "${var.sns_topic_arn}"
-#   depends_on = ["aws_cloudwatch_event_rule.default"]
-#   input      = "${var.sns_message_override}"
-# }
 data "aws_caller_identity" "default" {}
 
 resource "aws_db_event_subscription" "default" {
@@ -17,70 +10,4 @@ resource "aws_db_event_subscription" "default" {
   event_categories = [
     "failure",
   ]
-
-  depends_on = [aws_sns_topic_policy.default]
-}
-
-resource "aws_sns_topic_policy" "default" {
-  arn    = var.aws_sns_topic_arn
-  policy = data.aws_iam_policy_document.sns_topic_policy.json
-}
-
-data "aws_iam_policy_document" "sns_topic_policy" {
-  policy_id = "__default_policy_ID"
-
-  statement {
-    sid = "__default_statement_ID"
-
-    actions = [
-      "SNS:Subscribe",
-      "SNS:SetTopicAttributes",
-      "SNS:RemovePermission",
-      "SNS:Receive",
-      "SNS:Publish",
-      "SNS:ListSubscriptionsByTopic",
-      "SNS:GetTopicAttributes",
-      "SNS:DeleteTopic",
-      "SNS:AddPermission",
-    ]
-
-    effect    = "Allow"
-    resources = [var.aws_sns_topic_arn]
-
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
-    condition {
-      test     = "StringEquals"
-      variable = "AWS:SourceOwner"
-
-      values = [
-        data.aws_caller_identity.default.account_id,
-      ]
-    }
-  }
-
-  statement {
-    sid       = "Allow CloudwatchEvents"
-    actions   = ["sns:Publish"]
-    resources = [var.aws_sns_topic_arn]
-
-    principals {
-      type        = "Service"
-      identifiers = ["events.amazonaws.com"]
-    }
-  }
-
-  statement {
-    sid       = "Allow RDS Event Notification"
-    actions   = ["sns:Publish"]
-    resources = [var.aws_sns_topic_arn]
-
-    principals {
-      type        = "Service"
-      identifiers = ["rds.amazonaws.com"]
-    }
-  }
 }

--- a/main.tf
+++ b/main.tf
@@ -8,11 +8,12 @@
 data "aws_caller_identity" "default" {}
 
 resource "aws_db_event_subscription" "default" {
+  count       = "${length(var.db_instance_ids)}"
   name_prefix = "rds-event-sub"
   sns_topic   = "${var.aws_sns_topic_arn}"
 
   source_type = "db-instance"
-  source_ids  = ["${var.db_instance_id}"]
+  source_ids  = ["${var.db_instance_ids[count.index]}"]
 
   event_categories = [
     "failure",

--- a/main.tf
+++ b/main.tf
@@ -7,14 +7,9 @@
 # }
 data "aws_caller_identity" "default" {}
 
-# Make a topic
-resource "aws_sns_topic" "default" {
-  name_prefix = "rds-threshold-alerts"
-}
-
 resource "aws_db_event_subscription" "default" {
   name_prefix = "rds-event-sub"
-  sns_topic   = "${aws_sns_topic.default.arn}"
+  sns_topic   = "${var.aws_sns_topic_arn}"
 
   source_type = "db-instance"
   source_ids  = ["${var.db_instance_id}"]
@@ -32,7 +27,7 @@ resource "aws_db_event_subscription" "default" {
 }
 
 resource "aws_sns_topic_policy" "default" {
-  arn    = "${aws_sns_topic.default.arn}"
+  arn    = "${var.aws_sns_topic_arn}"
   policy = "${data.aws_iam_policy_document.sns_topic_policy.json}"
 }
 
@@ -55,7 +50,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     ]
 
     effect    = "Allow"
-    resources = ["${aws_sns_topic.default.arn}"]
+    resources = ["${var.aws_sns_topic_arn}"]
 
     principals {
       type        = "AWS"
@@ -75,7 +70,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
   statement {
     sid       = "Allow CloudwatchEvents"
     actions   = ["sns:Publish"]
-    resources = ["${aws_sns_topic.default.arn}"]
+    resources = ["${var.aws_sns_topic_arn}"]
 
     principals {
       type        = "Service"
@@ -86,7 +81,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
   statement {
     sid       = "Allow RDS Event Notification"
     actions   = ["sns:Publish"]
-    resources = ["${aws_sns_topic.default.arn}"]
+    resources = ["${var.aws_sns_topic_arn}"]
 
     principals {
       type        = "Service"

--- a/main.tf
+++ b/main.tf
@@ -8,23 +8,23 @@
 data "aws_caller_identity" "default" {}
 
 resource "aws_db_event_subscription" "default" {
-  count       = "${length(var.db_instance_ids)}"
+  count       = length(var.db_instance_ids)
   name_prefix = "rds-event-sub"
-  sns_topic   = "${var.aws_sns_topic_arn}"
+  sns_topic   = var.aws_sns_topic_arn
 
   source_type = "db-instance"
-  source_ids  = ["${var.db_instance_ids[count.index]}"]
+  source_ids  = [var.db_instance_ids[count.index]]
 
   event_categories = [
     "failure",
   ]
 
-  depends_on = ["aws_sns_topic_policy.default"]
+  depends_on = [aws_sns_topic_policy.default]
 }
 
 resource "aws_sns_topic_policy" "default" {
-  arn    = "${var.aws_sns_topic_arn}"
-  policy = "${data.aws_iam_policy_document.sns_topic_policy.json}"
+  arn    = var.aws_sns_topic_arn
+  policy = data.aws_iam_policy_document.sns_topic_policy.json
 }
 
 data "aws_iam_policy_document" "sns_topic_policy" {
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     ]
 
     effect    = "Allow"
-    resources = ["${var.aws_sns_topic_arn}"]
+    resources = [var.aws_sns_topic_arn]
 
     principals {
       type        = "AWS"
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
       variable = "AWS:SourceOwner"
 
       values = [
-        "${data.aws_caller_identity.default.account_id}",
+        data.aws_caller_identity.default.account_id,
       ]
     }
   }
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
   statement {
     sid       = "Allow CloudwatchEvents"
     actions   = ["sns:Publish"]
-    resources = ["${var.aws_sns_topic_arn}"]
+    resources = [var.aws_sns_topic_arn]
 
     principals {
       type        = "Service"
@@ -77,7 +77,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
   statement {
     sid       = "Allow RDS Event Notification"
     actions   = ["sns:Publish"]
-    resources = ["${var.aws_sns_topic_arn}"]
+    resources = [var.aws_sns_topic_arn]
 
     principals {
       type        = "Service"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,0 @@
-output "sns_topic_arn" {
-  description = "The ARN of the SNS topic"
-  value       = "${aws_sns_topic.default.arn}"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "aws_sns_topic_arn" {
   type        = "string"
 }
 
+variable "alarm_name_prefix" {
+  description = "Alarm name prefix for each alarm"
+  type        = "string"
+}
+
 variable "burst_balance_threshold" {
   description = "The minimum percent of General Purpose SSD (gp2) burst-bucket I/O credits available."
   type        = "string"

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,18 @@ variable "alarm_name_prefix" {
   default     = ""
 }
 
+variable "alarm_period" {
+  description = "The threshold is analyzed over the last X seconds, where X is alarm_period"
+  type        = string
+  default     = "600"
+}
+
+variable "alarm_evaluation_periods" {
+  description = "The number of periods over which data is compared to the specified threshold."
+  type        = string
+  default     = "1"
+}
+
 variable "burst_balance_threshold" {
   description = "The minimum percent of General Purpose SSD (gp2) burst-bucket I/O credits available."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,11 @@ variable "db_instance_id" {
   type        = "string"
 }
 
+variable "aws_sns_topic_arn" {
+  description = "The bla of the SNS topic you want to use for alerting"
+  type        = "string"
+}
+
 variable "burst_balance_threshold" {
   description = "The minimum percent of General Purpose SSD (gp2) burst-bucket I/O credits available."
   type        = "string"

--- a/variables.tf
+++ b/variables.tf
@@ -8,19 +8,19 @@ variable "aws_sns_topic_arn" {
   type        = string
 }
 
-variable "alarm_name_prefix" {
+variable "name_prefix" {
   description = "Alarm name prefix for each alarm"
   type        = string
   default     = ""
 }
 
-variable "alarm_period" {
+variable "period" {
   description = "The threshold is analyzed over the last X seconds, where X is alarm_period"
   type        = string
   default     = "600"
 }
 
-variable "alarm_evaluation_periods" {
+variable "evaluation_periods" {
   description = "The number of periods over which data is compared to the specified threshold."
   type        = string
   default     = "1"

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
-variable "db_instance_id" {
-  description = "The instance ID of the RDS database instance that you want to monitor."
-  type        = "string"
+variable "db_instance_ids" {
+  description = "The instance IDs of the RDS database instances that you want to monitor."
+  type        = "list"
 }
 
 variable "aws_sns_topic_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,46 +1,46 @@
 variable "db_instance_ids" {
   description = "The instance IDs of the RDS database instances that you want to monitor."
-  type        = "list"
+  type        = list(string)
 }
 
 variable "aws_sns_topic_arn" {
   description = "The bla of the SNS topic you want to use for alerting"
-  type        = "string"
+  type        = string
 }
 
 variable "alarm_name_prefix" {
   description = "Alarm name prefix for each alarm"
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "burst_balance_threshold" {
   description = "The minimum percent of General Purpose SSD (gp2) burst-bucket I/O credits available."
-  type        = "string"
+  type        = string
   default     = 20
 }
 
 variable "cpu_utilization_threshold" {
   description = "The maximum percentage of CPU utilization."
-  type        = "string"
+  type        = string
   default     = 80
 }
 
 variable "cpu_credit_balance_threshold" {
   description = "The minimum number of CPU credits (t2 instances only) available."
-  type        = "string"
+  type        = string
   default     = 20
 }
 
 variable "disk_queue_depth_threshold" {
   description = "The maximum number of outstanding IOs (read/write requests) waiting to access the disk."
-  type        = "string"
+  type        = string
   default     = 64
 }
 
 variable "freeable_memory_threshold" {
   description = "The minimum amount of available random access memory in Byte."
-  type        = "string"
+  type        = string
   default     = 64000000
 
   # 64 Megabyte in Byte
@@ -48,7 +48,7 @@ variable "freeable_memory_threshold" {
 
 variable "free_storage_space_threshold" {
   description = "The minimum amount of available storage space in Byte."
-  type        = "string"
+  type        = string
   default     = 2000000000
 
   # 2 Gigabyte in Byte
@@ -56,7 +56,7 @@ variable "free_storage_space_threshold" {
 
 variable "swap_usage_threshold" {
   description = "The maximum amount of swap space used on the DB instance in Byte."
-  type        = "string"
+  type        = string
   default     = 256000000
 
   # 256 Megabyte in Byte

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,7 @@ variable "aws_sns_topic_arn" {
 variable "alarm_name_prefix" {
   description = "Alarm name prefix for each alarm"
   type        = "string"
+  default     = ""
 }
 
 variable "burst_balance_threshold" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,11 @@
 variable "db_instance_ids" {
   description = "The instance IDs of the RDS database instances that you want to monitor."
-  type        = list(string)
+  type        = set(string)
 }
 
 variable "db_master_ids" {
   description = "The instance IDs of the RDS database master instances that you want to monitor."
-  type        = list(string)
+  type        = set(string)
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,12 @@ variable "period" {
   default     = "600"
 }
 
+variable "datapoints_to_alarm" {
+  description = "The number of datapoints that must be breaching to trigger the alarm."
+  type        = string
+  default     = "1"
+}
+
 variable "evaluation_periods" {
   description = "The number of periods over which data is compared to the specified threshold."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "db_instance_ids" {
   type        = list(string)
 }
 
+variable "db_master_ids" {
+  description = "The instance IDs of the RDS database master instances that you want to monitor."
+  type        = list(string)
+  default     = []
+}
+
 variable "aws_sns_topic_arn" {
   description = "The bla of the SNS topic you want to use for alerting"
   type        = string


### PR DESCRIPTION
* Upgrades code to be terraform .12 compatible fixes #16
* Makes alarm names unique fixes #5 
* __Breaking change__: requires sns topic param instead of creating one for the user. The user may already have a prexisting SNS topic that they might want to use. The repo should just concern itself with alarms and not with SNS.
* __Breaking change__: `db_instance_id` changed to `db_instance_ids` to support multiple db's
* add `alarm_period` and `alarm_evaluation_periods` params

We are running this change in production for [15Five](http://15five.com/).