### PR TITLE
Add Oldest Replication Slot Lag RDS alarm

### DIFF
--- a/alarms.tf
+++ b/alarms.tf
@@ -17,6 +17,7 @@ locals {
     "disk_queue_depth_too_high",
     "freeable_memory_too_low",
     "free_storage_space_threshold",
+    "oldest_replication_too_high",
     "swap_usage_too_high"
   ])
 }
@@ -141,7 +142,7 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "oldest_replication_too_high" {
-  alarm_name          = "oldest_replication_too_high"
+  alarm_name          = module.label["oldest_replication_too_high"].id
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "OldestReplicationSlotLag"
@@ -150,8 +151,8 @@ resource "aws_cloudwatch_metric_alarm" "oldest_replication_too_high" {
   statistic           = "Average"
   threshold           = local.thresholds["OldestReplicationThreshold"]
   alarm_description   = "Average database replication lag over last 10 minutes too high, disk may fill"
-  alarm_actions       = [aws_sns_topic.default.arn]
-  ok_actions          = [aws_sns_topic.default.arn]
+  alarm_actions       = aws_sns_topic.default.*.arn
+  ok_actions          = aws_sns_topic.default.*.arn
 
   dimensions = {
     DBInstanceIdentifier = var.db_instance_id

--- a/alarms.tf
+++ b/alarms.tf
@@ -1,12 +1,13 @@
 locals {
   thresholds = {
-    BurstBalanceThreshold     = min(max(var.burst_balance_threshold, 0), 100)
-    CPUUtilizationThreshold   = min(max(var.cpu_utilization_threshold, 0), 100)
-    CPUCreditBalanceThreshold = max(var.cpu_credit_balance_threshold, 0)
-    DiskQueueDepthThreshold   = max(var.disk_queue_depth_threshold, 0)
-    FreeableMemoryThreshold   = max(var.freeable_memory_threshold, 0)
-    FreeStorageSpaceThreshold = max(var.free_storage_space_threshold, 0)
-    SwapUsageThreshold        = max(var.swap_usage_threshold, 0)
+    BurstBalanceThreshold      = min(max(var.burst_balance_threshold, 0), 100)
+    CPUUtilizationThreshold    = min(max(var.cpu_utilization_threshold, 0), 100)
+    CPUCreditBalanceThreshold  = max(var.cpu_credit_balance_threshold, 0)
+    DiskQueueDepthThreshold    = max(var.disk_queue_depth_threshold, 0)
+    FreeableMemoryThreshold    = max(var.freeable_memory_threshold, 0)
+    FreeStorageSpaceThreshold  = max(var.free_storage_space_threshold, 0)
+    OldestReplicationThreshold = max(var.oldest_replication_threshold, 0)
+    SwapUsageThreshold         = max(var.swap_usage_threshold, 0)
   }
 
   alarm_names = toset([
@@ -138,6 +139,25 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
     DBInstanceIdentifier = var.db_instance_id
   }
 }
+
+resource "aws_cloudwatch_metric_alarm" "oldest_replication_too_high" {
+  alarm_name          = "oldest_replication_too_high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "OldestReplicationSlotLag"
+  namespace           = "AWS/RDS"
+  period              = "600"
+  statistic           = "Average"
+  threshold           = local.thresholds["OldestReplicationThreshold"]
+  alarm_description   = "Average database replication lag over last 10 minutes too high, disk may fill"
+  alarm_actions       = [aws_sns_topic.default.arn]
+  ok_actions          = [aws_sns_topic.default.arn]
+
+  dimensions = {
+    DBInstanceIdentifier = var.db_instance_id
+  }
+}
+
 
 resource "aws_cloudwatch_metric_alarm" "swap_usage_too_high" {
   alarm_name          = module.label["swap_usage_too_high"].id

--- a/variables.tf
+++ b/variables.tf
@@ -43,6 +43,13 @@ variable "free_storage_space_threshold" {
   # 2 Gigabyte in Byte
 }
 
+variable "oldest_replication_threshold" {
+  description = "The maximum amount of replication lag space in Megabyte."
+  type        = string
+  default     = 1000
+  # 1 Gigabyte in Megabyte
+}
+
 variable "swap_usage_threshold" {
   description = "The maximum amount of swap space used on the DB instance in Byte."
   type        = number


### PR DESCRIPTION
Fix #48

This pulls in a patch from @mgeist on https://github.com/BetterWorks/terraform-aws-rds-cloudwatch-sns-alarms

Steps to replicate this patch:

```shell
git clone git@github.com:dazza-codes/terraform-aws-rds-cloudwatch-sns-alarms.git 
cd terraform-aws-rds-cloudwatch-sns-alarms
git remote add betterworks git@github.com:BetterWorks/terraform-aws-rds-cloudwatch-sns-alarms.git
git fetch betterworks 
git cherry-pick 3b67e0959695533a28a79242c2d9bc5d09b24394
git checkout -b add-OldestReplicationSlotLag
git push --set-upstream origin add-OldestReplicationSlotLag
```

There are no format changes added by this PR (other than those already in the BetterWorks commit).
```
❯ terraform fmt *.tf

```

This PR does update the BetterWorks patch for the latest cloudposse module details.  When consuming the PR branch as a module, the `terraform validate` is working, e.g. a consumer can try:

```
# https://github.com/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms/issues/48
# https://github.com/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms/pull/49
module "rds_alarms" {
  source         = "git::https://github.com/dazza-codes/terraform-aws-rds-cloudwatch-sns-alarms.git?ref=add-OldestReplicationSlotLag"
  db_instance_id = aws_db_instance.rds.id
  namespace      = var.namespace
  name           = var.project_name
  stage          = var.stage
}
```
