### PR TITLE
Bugfix: Breaking change on aws_db_instance 5.0.0

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -19,6 +19,6 @@ resource "aws_db_instance" "default" {
 
 module "rds_alarms" {
   source         = "../../"
-  db_instance_id = aws_db_instance.default.id
+  db_instance_id = aws_db_instance.default.identifier
   context        = module.this.context
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -2,6 +2,6 @@ output "rds_alarms_sns_topic_arn" {
   value = module.rds_alarms.sns_topic_arn
 }
 
-output "rds_arn" {
-  value = aws_db_instance.default.id
+output "rds_instance_id" {
+  value = aws_db_instance.default.identifier
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -50,6 +50,6 @@ func TestExamplesComplete(t *testing.T) {
 		randID,
 		"rds-threshold-alerts"), snsTopicArn)
 
-	rdsArn := terraform.Output(t, terraformOptions, "rds_arn")
+	rdsArn := terraform.Output(t, terraformOptions, "rds_instance_id")
 	assert.Equal(t, fmt.Sprintf("eg-test-rds-alarms-%s", randID), rdsArn)
 }


### PR DESCRIPTION
A [breaking change](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#500-may-25-2023) was made in aws_db_instance 5.0.0, changing id to be the `dbi-resource-id` rather than database identifier.  Updating example to use `identifier`